### PR TITLE
fix: updated recover_account args and result object usage

### DIFF
--- a/src/contexts/ConferenceContext.tsx
+++ b/src/contexts/ConferenceContext.tsx
@@ -61,12 +61,12 @@ export const ConferenceProvider = ({
         const recoveredAccountId = await keypomInstance.viewCall({
           contractId: TOKEN_FACTORY_CONTRACT,
           methodName: "recover_account",
-          args: { key: getPubFromSecret(secretKey) },
+          args: { key_or_account_id: getPubFromSecret(secretKey) },
         });
         const balance = await keypomInstance.viewCall({
           contractId: TOKEN_FACTORY_CONTRACT,
           methodName: "ft_balance_of",
-          args: { account_id: recoveredAccountId },
+          args: { account_id: recoveredAccountId.account_id },
         });
         console.log("recovered account id: ", recoveredAccountId);
         console.log("balance: ", balance);

--- a/src/hooks/useAccountData.tsx
+++ b/src/hooks/useAccountData.tsx
@@ -11,24 +11,24 @@ export const fetchAccountData = async (secretKey: string) => {
   try {
     const pubKey = getPubFromSecret(secretKey);
 
-    const accountId = await keypomInstance.viewCall({
+    const recoveredAccount = await keypomInstance.viewCall({
       contractId: TOKEN_FACTORY_CONTRACT,
       methodName: "recover_account",
-      args: { key: pubKey },
+      args: { key_or_account_id: pubKey },
     });
 
-    if (!accountId) {
+    if (!recoveredAccount) {
       throw new Error("Account not found");
     }
 
     const balance = await keypomInstance.viewCall({
       contractId: TOKEN_FACTORY_CONTRACT,
       methodName: "ft_balance_of",
-      args: { account_id: accountId },
+      args: { account_id: recoveredAccount.account_id },
     });
 
     return {
-      accountId,
+      accountId: recoveredAccount.account_id,
       balance,
     };
   } catch (error) {


### PR DESCRIPTION
- Changed `recover_account` args from `key` to `key_or_account_id`
- Also changed dependent function args because the result object of `recover_account` was updated too. 

Resolves #62 